### PR TITLE
Updating build flags.

### DIFF
--- a/sucpp/Makefile
+++ b/sucpp/Makefile
@@ -81,11 +81,12 @@ ifeq (,$(findstring pgi,$(COMPILER)))
 	CPPFLAGS += -Wextra -Wno-unused-parameter
 endif
 
-ifeq ($(PLATFORM),Darwin)
+#ifeq ($(PLATFORM),Darwin)
         BLASLIB=-llapacke -lcblas
-else
-        BLASLIB=-lcblas
-endif
+#else
+#        BLASLIB=-lcblas
+#endif
+LDDFLAGS += -shlib
 
 
 CPPFLAGS += -Wall  -std=c++11 -pedantic -I. $(OPT) -fPIC -L$(CONDA_PREFIX)/lib


### PR DESCRIPTION
Building on ubuntu 20 (container) doesn't work without a few updates to the Makefile. 